### PR TITLE
upgrade manifest version: deployment to v1, istio to v1beta1

### DIFF
--- a/ab/deployment-new.yaml
+++ b/ab/deployment-new.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-02
 spec:
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
        labels:

--- a/ab/deployment-old.yaml
+++ b/ab/deployment-old.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-01
 spec:
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
        labels:

--- a/ab/destinationrule.yaml
+++ b/ab/destinationrule.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: app

--- a/ab/gateway.yaml
+++ b/ab/gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: app

--- a/ab/virtualservice-split.yaml
+++ b/ab/virtualservice-split.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: app

--- a/ab/virtualservice.yaml
+++ b/ab/virtualservice.yaml
@@ -24,7 +24,7 @@ spec:
       targetPort: 8080
   type: NodePort
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: app

--- a/bluegreen/deployment-new.yaml
+++ b/bluegreen/deployment-new.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-02
 spec:
+  selector:
+    matchLabels:
+      app: demo-app-v2
   template:
     metadata:
        labels:

--- a/bluegreen/deployment-old.yaml
+++ b/bluegreen/deployment-old.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-01
 spec:
+  selector:
+    matchLabels:
+      app: demo-app-v1
   template:
     metadata:
        labels:

--- a/canary/deployment-new.yaml
+++ b/canary/deployment-new.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-02
 spec:
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
        labels:

--- a/canary/deployment-old.yaml
+++ b/canary/deployment-old.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-01
 spec:
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
        labels:

--- a/canary/destinationrule.yaml
+++ b/canary/destinationrule.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: app

--- a/canary/gateway.yaml
+++ b/canary/gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: app

--- a/canary/virtualservice-split.yaml
+++ b/canary/virtualservice-split.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: app

--- a/canary/virtualservice.yaml
+++ b/canary/virtualservice.yaml
@@ -24,7 +24,7 @@ spec:
       targetPort: 8080
   type: NodePort
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: app

--- a/recreate/deployment-new.yaml
+++ b/recreate/deployment-new.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
@@ -20,6 +20,9 @@ spec:
   replicas: 3
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
        labels:

--- a/recreate/deployment-old.yaml
+++ b/recreate/deployment-old.yaml
@@ -1,32 +1,27 @@
-# Copyright 2019 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: app
   name: app
 spec:
   replicas: 3
-  strategy:
+  selector:
+    matchLabels:
+      app: demo-app
+  strategy: 
     type: Recreate
   template:
     metadata:
-       labels:
-         app: demo-app
+      creationTimestamp: null
+      labels:
+        app: demo-app
     spec:
       containers:
-        - name: app
-          image: gcr.io/cloud-solutions-images/app:current
-          ports:
-            - containerPort: 8080
+      - image: gcr.io/cloud-solutions-images/app:current
+        name: app
+        ports:
+        - containerPort: 8080
+        resources: {}
+status: {}

--- a/rollingupdate/deployment-new.yaml
+++ b/rollingupdate/deployment-new.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
@@ -23,6 +23,9 @@ spec:
     rollingUpdate:
        maxSurge: 30%
        maxUnavailable: 30%
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
        labels:

--- a/rollingupdate/deployment-old.yaml
+++ b/rollingupdate/deployment-old.yaml
@@ -1,30 +1,25 @@
-# Copyright 2019 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
+  labels:
+    app: app
   name: app
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
-       labels:
-         app: demo-app
+      creationTimestamp: null
+      labels:
+        app: demo-app
     spec:
       containers:
-        - name: app
-          image: gcr.io/cloud-solutions-images/app:current
-          ports:
-            - containerPort: 8080
+      - image: gcr.io/cloud-solutions-images/app:current
+        name: app
+        ports:
+        - containerPort: 8080
+        resources: {}
+status: {}

--- a/shadow/deployment-new.yaml
+++ b/shadow/deployment-new.yaml
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-02
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
       labels:

--- a/shadow/deployment-old.yaml
+++ b/shadow/deployment-old.yaml
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-01
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: demo-app
   template:
     metadata:
       labels:

--- a/shadow/gateway.yaml
+++ b/shadow/gateway.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: app

--- a/shadow/virtualservice-mirror.yaml
+++ b/shadow/virtualservice-mirror.yaml
@@ -24,7 +24,7 @@ spec:
     app: demo-app
     version: "02"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: app

--- a/shadow/virtualservice.yaml
+++ b/shadow/virtualservice.yaml
@@ -24,7 +24,7 @@ spec:
     app: demo-app
     version: "01"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: app


### PR DESCRIPTION
- Upgrade deployment api version from v1beta1 to v1
- Upgrade a number of istio object from v1alpha3 to v1beta1. 
- tested with istio 1.9.1